### PR TITLE
Configure markdown extensions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ theme:
     - content.action.edit
 plugins:
   - search
+markdown_extensions:
+  - footnotes
+  - tables
 extra:
   social:
     - icon: fontawesome/solid/globe


### PR DESCRIPTION
Enable [footnotes](https://python-markdown.github.io/extensions/footnotes/) and [tables](https://python-markdown.github.io/extensions/tables/).